### PR TITLE
personal-calls: add heroku-login recipe

### DIFF
--- a/personal-calls/Makefile
+++ b/personal-calls/Makefile
@@ -44,6 +44,10 @@ build-deployment: ## Build for deployment
 	@echo "Building app..."
 	docker build --build-arg PUBLIC_URL="$(PUBLIC_URL_TARGET)" --build-arg RELEASE_DATE="$(VERSION)" -t call-home .
 
+heroku-login: ## Login to heroku
+	heroku login
+	heroku container:login
+
 deploy: build-deployment ## Deploy app to cloud
 ifeq ($(DEPLOY_TARGET),heroku)
 	@echo "Deploying to Heroku..."

--- a/personal-calls/Makefile
+++ b/personal-calls/Makefile
@@ -55,7 +55,7 @@ endif
 	deploy-sentry
 
 deploy-heroku: ## Deploy to heroku
-	docker tag call-home registry.heroku.com/$(HEROKU_APP)/web
+	docker tag call-home registry.heroku.com/$(HEROKU_APP_TARGET)/web
 	docker push registry.heroku.com/$(HEROKU_APP_TARGET)/web
 	heroku container:release web --app $(HEROKU_APP_TARGET)
 

--- a/personal-calls/Makefile
+++ b/personal-calls/Makefile
@@ -56,7 +56,7 @@ else ifeq ($(DEPLOY_TARGET),cloudrun)
 	@echo "Deploying to Cloud Run..."
 	$(MAKE) deploy-cloudrun
 endif
-	deploy-sentry
+	$(MAKE) deploy-sentry
 
 deploy-heroku: ## Deploy to heroku
 	docker tag call-home registry.heroku.com/$(HEROKU_APP_TARGET)/web


### PR DESCRIPTION
I tried to deploy to staging and got reminded of the need to login. Add a make target (well, we use Make more as a recipebook I guess) that logs into heroku on the CLI and in Docker.

Also, I found a bug in the deploy-heroku target and fixed it.