### PR TITLE
build: revert cloud build service account data source

### DIFF
--- a/infra/staging/main.tf
+++ b/infra/staging/main.tf
@@ -48,16 +48,15 @@ resource "google_project_service" "cloud_build_api" {
   service = "cloudbuild.googleapis.com"
 }
 
-data "google_service_account" "cloud_build_service_account" {
-  account_id = google_project_service.cloud_build_api.id
-}
-
 // Enable App Engine permissions for the Cloud Build service account
 resource "google_project_iam_binding" "app_engine_admin" {
   project = data.google_project.project.project_id
   role = "roles/appengine.appAdmin"
   members = [
-    data.google_service_account.cloud_build_service_account.member
+    "serviceAccount:${data.google_project.project.number}@cloudbuild.gserviceaccount.com"
+  ]
+  depends_on = [
+    google_project_service.cloud_build_api
   ]
 }
 
@@ -66,7 +65,10 @@ resource "google_project_iam_binding" "service_account_user" {
   project = data.google_project.project.project_id
   role = "roles/iam.serviceAccountUser"
   members = [
-    data.google_service_account.cloud_build_service_account.member
+    "serviceAccount:${data.google_project.project.number}@cloudbuild.gserviceaccount.com"
+  ]
+  depends_on = [
+    google_project_service.cloud_build_api
   ]
 }
 


### PR DESCRIPTION
This PR reverts the changes I made as a result of the discussion in https://github.com/bettersg/call-home/pull/87#discussion_r1038876514, where I added a data source for the cloud build service account. Currently, when applying the new configs, terraform complains and throws an error because the data source for the service account is returning null.

I'm not sure why it worked when I tested it before, but doesn't work now :( Maybe I forgot to properly save the config file before testing it.

Here, I opted for a revert instead of a fix because I couldn't find a way to get the correct `account_id` for the cloud build service account. Another (proper) way appears to be using a [project service identity](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/project_service_identity), but that requires the beta version of the google terraform provider, which may be more trouble than it's worth.

(In other news: I've moved the state bucket `call-home-staging-terraform-state-bucket` from `call-home-staging` to `call-home-infra` by deleting and re-creating the bucket in the new project, and transferring the contents over. It seems unlikely that this migration caused the above issue with the cloud build service account, since terraform seems to have no issues with all the other resources.)