### PR TITLE
build: enable cloud sql admin api

### DIFF
--- a/infra/staging/main.tf
+++ b/infra/staging/main.tf
@@ -40,6 +40,13 @@ data "google_project" "project" {
   project_id = var.project_id
 }
 
+// Enable Cloud SQL Admin API to allow App Engine to connect to the database
+// See: https://cloud.google.com/sql/docs/mysql/connect-app-engine-standard
+resource "google_project_service" "sql_admin_api" {
+  project = data.google_project.project.project_id
+  service = "sqladmin.googleapis.com"
+}
+
 // Enable Cloud Build API and grant its service account App Engine and Service Account User
 // permissions to allow developers to build and deploy applications to App Engine using gcloud SDK.
 // See: https://cloud.google.com/build/docs/deploying-builds/deploy-appengine


### PR DESCRIPTION
The Cloud SQL Admin API must be enabled for the App Engine app to connect to a Cloud SQL instance, see https://cloud.google.com/sql/docs/mysql/connect-app-engine-standard

This follows up on https://github.com/bettersg/call-home/pull/87#discussion_r1038876358, apparently the API needed to be enabled after all! After applying the new terraform config in this PR, the 500 error on strapi staging goes away. :)