### PR TITLE
personal-calls: Verify FIN

### DIFF
--- a/personal-calls/backend/src/index.ts
+++ b/personal-calls/backend/src/index.ts
@@ -20,6 +20,7 @@ import {
   DormValidation as dormValidationRoutes,
   FacebookDormCode as facebookDormCodeRoutes,
   Feature as featureRoutes,
+  FinValidation as finValidationRoutes,
   OAuth as oauthRoutes,
   PeriodicCredit as periodicCreditRoutes,
   PhoneNumberValidation as phoneNumberValidationRoutes,
@@ -71,6 +72,7 @@ app.use('/features', secureRoutes, featureRoutes);
 // TODO For backwards-compatibility
 app.use('/passwordless', secureRoutes, phoneNumberValidationRoutes);
 app.use('/phone-number-validation', secureRoutes, phoneNumberValidationRoutes);
+app.use('/fin-validation', secureRoutes, finValidationRoutes);
 app.use('/workpass-validation', secureRoutes, workpassValidationRoutes);
 app.use(
   '/admin-granted-validation',

--- a/personal-calls/backend/src/models/FinValidation.ts
+++ b/personal-calls/backend/src/models/FinValidation.ts
@@ -1,0 +1,33 @@
+import {
+  AllowNull,
+  Column,
+  DataType,
+  Default,
+  Model,
+  Table,
+  Unique,
+} from 'sequelize-typescript';
+
+@Table
+class FinValidation extends Model<FinValidation> {
+  @AllowNull(false)
+  @Unique
+  @Column
+  userId: number;
+
+  // sha256 of the given FIN. sha256 is considered preimage resistant, which is
+  // exactly what we want i.e. we don't want to be able to generate a valid FIN
+  // given its hash value. More specifically, this is the bas64 encoding of the
+  // utf8 encoding of the FIN.
+  // This is the same approach taken for work pass serial numbers.
+  @Unique
+  @Column(DataType.TEXT)
+  finSha256: string | null;
+
+  @Default(false)
+  @Column
+  isFinValidated: boolean;
+}
+
+export default FinValidation;
+export { FinValidation };

--- a/personal-calls/backend/src/models/index.ts
+++ b/personal-calls/backend/src/models/index.ts
@@ -4,6 +4,7 @@ import AllowlistEntry from './AllowlistEntry';
 import Call from './Call';
 import Contact from './Contact';
 import Dorm from './Dorm';
+import FinValidation from './FinValidation';
 import PeriodicCredit from './PeriodicCredit';
 import Transaction from './Transaction';
 import TwilioCall, { CallStatus, CallType } from './TwilioCall';
@@ -25,6 +26,7 @@ sequelize.addModels([
   Contact,
   Dorm,
   DormValidation,
+  FinValidation,
   PeriodicCredit,
   RedeemableCode,
   Transaction,
@@ -142,6 +144,7 @@ export {
   Contact,
   Dorm,
   DormValidation,
+  FinValidation,
   PeriodicCredit,
   RedeemableCode,
   RedeemableCodeType,

--- a/personal-calls/backend/src/routes/Feature.ts
+++ b/personal-calls/backend/src/routes/Feature.ts
@@ -21,6 +21,8 @@ function FeaturesRoutes(
         featureService.getEdgeExperimentFlag(userExperimentConfig),
       FEEDBACK_DIALOG: featureService.shouldEnableFeedbackDialog(),
       CREDIT_CAP: featureService.shouldEnableCreditCap(),
+      DISABLE_WORKPASS: featureService.shouldDisableWorkpassValidation(),
+      ENABLE_FIN: featureService.shouldEnableFinValidation(),
     };
     return res.status(200).json(features);
   });

--- a/personal-calls/backend/src/routes/FinValidation.ts
+++ b/personal-calls/backend/src/routes/FinValidation.ts
@@ -1,0 +1,36 @@
+import express, { Router } from 'express';
+import * as z from 'zod';
+import type { FinValidation } from '../services';
+import { validateRequest } from './helpers/validation';
+
+const POST_SCHEMA = z.object({
+  body: z.object({
+    fin: z.string(),
+  }),
+});
+
+function FinValidationRoutes(finValidation: typeof FinValidation): Router {
+  const router = express.Router();
+
+  router.post(
+    '/',
+    validateRequest(POST_SCHEMA, async (parsedReq, res, req) => {
+      const { fin } = parsedReq.body;
+      const { user } = req;
+
+      const validationResult = await finValidation.validateUser(user.id, fin);
+
+      if (validationResult === 'VALID') {
+        return res.status(200).send();
+      }
+
+      return res.status(400).json({
+        reason: validationResult
+      });
+    })
+  );
+
+  return router;
+}
+
+export default FinValidationRoutes;

--- a/personal-calls/backend/src/routes/index.ts
+++ b/personal-calls/backend/src/routes/index.ts
@@ -13,6 +13,7 @@ import Dorm from './Dorm';
 import AllowlistEntry from './AllowlistEntry';
 import AdminGrantedValidation from './AdminGrantedValidation';
 import DormValidation from './DormValidation';
+import FinValidation from './FinValidation';
 import PhoneNumberValidation from './PhoneNumberValidation';
 import WorkpassValidation from './WorkpassValidation';
 import FacebookDormCode from './FacebookDormCode';
@@ -48,6 +49,7 @@ const facebookDormCode = FacebookDormCode(
   services.FacebookDormCodeRedemption,
   services.RedeemableCode
 );
+const finValidationRoute = FinValidation(services.FinValidation);
 
 export {
   allowlistEntryRoute as AllowlistEntry,
@@ -59,6 +61,7 @@ export {
   dormValidationRoute as DormValidation,
   facebookDormCode as FacebookDormCode,
   featureRoute as Feature,
+  finValidationRoute as FinValidation,
   middlewares,
   oAuthRoute as OAuth,
   periodicCreditRoute as PeriodicCredit,

--- a/personal-calls/backend/src/services/Feature.ts
+++ b/personal-calls/backend/src/services/Feature.ts
@@ -3,12 +3,14 @@ import { Edge } from '@call-home/shared/types/CallExperimentFlags';
 import { UserExperimentConfig } from '../models';
 
 const {
-  ENABLE_ALLOWLIST_SMS,
   DISABLE_ALLOWLIST,
-  ENABLE_DORM_VALIDATION,
   DISABLE_PERIODIC_JOBS,
+  DISABLE_WORKPASS_VALIDATION,
+  ENABLE_ALLOWLIST_SMS,
+  ENABLE_DORM_VALIDATION,
   ENABLE_EDGE_EXPERIMENT,
   ENABLE_FEEDBACK_DIALOG,
+  ENABLE_FIN_VALIDATION,
   ENABLE_SUPPORT_SERVICES,
 } = process.env;
 
@@ -70,13 +72,23 @@ function shouldEnableSupportServices() {
   return Boolean(ENABLE_SUPPORT_SERVICES);
 }
 
+function shouldDisableWorkpassValidation() {
+  return Boolean(DISABLE_WORKPASS_VALIDATION);
+}
+
+function shouldEnableFinValidation() {
+  return Boolean(ENABLE_FIN_VALIDATION);
+}
+
 export {
   shouldDisableAllowlist,
-  shouldEnableAllowlistSms,
-  shouldEnableDormValidation,
   shouldDisablePeriodicJobs,
-  shouldEnableFeedbackDialog,
+  shouldDisableWorkpassValidation,
+  shouldEnableAllowlistSms,
   shouldEnableCreditCap,
+  shouldEnableDormValidation,
+  shouldEnableFeedbackDialog,
+  shouldEnableFinValidation,
   shouldEnableSupportServices,
   getEdgeExperimentFlag,
 };

--- a/personal-calls/backend/src/services/FinValidation.ts
+++ b/personal-calls/backend/src/services/FinValidation.ts
@@ -1,0 +1,88 @@
+import crypto from 'crypto';
+import validateFIN, { FinResult } from '../util/VerifyFIN';
+import type { FinValidation as FinValidationEntity } from '../models';
+
+// TODO this is duped from ./WorkpassValidation and may be worth deduping.
+
+function hashSha256(data: string): string {
+  return crypto
+    .createHash('sha256')
+    .update(Buffer.from(data, 'utf8'))
+    .digest('base64');
+}
+
+function FinValidationService(FinValidationModel: typeof FinValidationEntity) {
+  async function getValidationByFinSha256(finSha256: string) {
+    return FinValidationModel.findOne({
+      where: {
+        finSha256,
+      },
+    });
+  }
+
+  async function createFinValidationForUser(userId: number) {
+    const currentFinValidation = await FinValidationModel.findOne({
+      where: {
+        userId,
+      },
+    });
+    if (currentFinValidation) {
+      return currentFinValidation;
+    }
+    return FinValidationModel.create({ userId });
+  }
+
+  async function getFinValidationForUser(userId: number) {
+    return FinValidationModel.findOne({
+      where: {
+        userId,
+      },
+    });
+  }
+
+  async function updateFinValidation(
+    userId: number,
+    validationState: Partial<FinValidationEntity>
+  ) {
+    return FinValidationModel.update(validationState, {
+      where: { userId },
+    });
+  }
+
+  // Define a simple pair of functions that will validate/invalidate a user
+  async function invalidateUser(userId: number) {
+    return updateFinValidation(userId, {
+      isFinValidated: false,
+      finSha256: null,
+    });
+  }
+
+  async function validateUser(userId: number, fin: string): Promise<FinResult> {
+    const finValidation = await createFinValidationForUser(userId);
+    const finResult = validateFIN(fin)
+
+    if (finResult !== 'VALID') {
+      return finResult;
+    }
+    const finSha256 = hashSha256(fin.toUpperCase());
+    const existingFinUser = await getValidationByFinSha256(finSha256);
+    if (existingFinUser) {
+      await invalidateUser(existingFinUser.userId);
+    }
+    await updateFinValidation(userId, {
+      finSha256,
+      isFinValidated: true,
+    });
+    return finResult;
+  }
+
+  return {
+    createFinValidationForUser,
+    getFinValidationForUser,
+    validateUser,
+    invalidateUser,
+  };
+}
+
+export { FinValidationService };
+export default FinValidationService;

--- a/personal-calls/backend/src/services/UserValidation.ts
+++ b/personal-calls/backend/src/services/UserValidation.ts
@@ -86,15 +86,13 @@ function UserValidationService(
     if (verificationState.adminGranted) {
       return true;
     }
-
+    let isVerified = true;
+    isVerified = isVerified && verificationState.phoneNumber;
+    isVerified = isVerified && verificationState.workpass;
     if (featureService.shouldEnableDormValidation()) {
-      return (
-        verificationState.phoneNumber &&
-        verificationState.workpass &&
-        verificationState.dorm
-      );
+      isVerified = isVerified && verificationState.dorm;
     }
-    return verificationState.phoneNumber && verificationState.workpass;
+    return isVerified;
   }
 
   return {

--- a/personal-calls/backend/src/services/index.ts
+++ b/personal-calls/backend/src/services/index.ts
@@ -71,6 +71,7 @@ const userValidationService = UserValidation(
   adminGrantedValidationService,
   dormValidationService,
   phoneNumberValidationService,
+  finValidationService,
   workpassValidationService
 );
 const callService = Call(

--- a/personal-calls/backend/src/services/index.ts
+++ b/personal-calls/backend/src/services/index.ts
@@ -14,6 +14,7 @@ import CodeRedemption from './CodeRedemption';
 import AdminGrantedValidation from './AdminGrantedValidation';
 import PhoneNumberValidation from './PhoneNumberValidation';
 import DormValidation from './DormValidation';
+import FinValidation, { FinValidationService } from './FinValidation';
 import WorkpassValidation from './WorkpassValidation';
 import * as WorkpassClient from './WorkpassClient';
 import UserValidation, { VerificationState } from './UserValidation';
@@ -31,6 +32,7 @@ const dormService = Dorm(models.Dorm);
 const walletService = Wallet(models.Wallet, models.WalletTransaction);
 const redeemableCodeService = RedeemableCode(models.RedeemableCode);
 
+const finValidationService = FinValidationService(models.FinValidation);
 const allowlistEntryService = AllowlistEntry(
   models.AllowlistEntry,
   TwilioClient
@@ -115,6 +117,7 @@ export {
   dormService as Dorm,
   dormValidationService as DormValidation,
   facebookDormCodeRedemptionService as FacebookDormCodeRedemption,
+  finValidationService as FinValidation,
   periodicCreditService as PeriodicCredit,
   redeemableCodeService as RedeemableCode,
   transactionService as Transaction,

--- a/personal-calls/backend/src/util/VerifyFIN.test.ts
+++ b/personal-calls/backend/src/util/VerifyFIN.test.ts
@@ -1,53 +1,57 @@
 import validateFIN from './VerifyFIN';
 
 test('Valid FIN', () => {
-  expect(validateFIN('F1234567N')).toBeTruthy();
+  expect(validateFIN('F1234567N')).toBe('VALID');
 });
 
 test('Lowercase first alphabet', () => {
-  expect(validateFIN('f3725759K')).toBeTruthy();
+  expect(validateFIN('f3725759K')).toBe('VALID');
 });
 
 test('Lowercase last alphabet', () => {
-  expect(validateFIN('G8976611m')).toBeTruthy();
+  expect(validateFIN('G8976611m')).toBe('VALID');
 });
 
-test('Invalid FIN', () => {
-  expect(validateFIN('G1234567A')).toBeFalsy();
+test('Bad checksum', () => {
+  expect(validateFIN('G1234567A')).toBe('BAD_CHECKSUM');
 });
 
 test('Less than 9 characters', () => {
-  expect(validateFIN('F123456A')).toBeFalsy();
+  expect(validateFIN('F123456A')).toBe('BAD_FORMAT');
 });
 
 test('More than 9 characters', () => {
-  expect(validateFIN('G12345678A')).toBeFalsy();
+  expect(validateFIN('G12345678A')).toBe('BAD_FORMAT');
 });
 
 test('Numbers only without alphabet', () => {
-  expect(validateFIN('123456789')).toBeFalsy();
+  expect(validateFIN('123456789')).toBe('BAD_SERIES');
+});
+
+test('Bad series', () => {
+  expect(validateFIN('R1234567A')).toBe('BAD_SERIES');
 });
 
 test('M series', () => {
   // One of each checksum letter
-  expect(validateFIN('M4627182X')).toBeTruthy();
-  expect(validateFIN('M1108730W')).toBeTruthy();
-  expect(validateFIN('M4503401U')).toBeTruthy();
-  expect(validateFIN('M4460557T')).toBeTruthy();
-  expect(validateFIN('M7986532R')).toBeTruthy();
-  expect(validateFIN('M1782041Q')).toBeTruthy();
-  expect(validateFIN('M2682514P')).toBeTruthy();
-  expect(validateFIN('M2966069N')).toBeTruthy();
-  expect(validateFIN('M2966078J')).toBeTruthy();
-  expect(validateFIN('M2083705L')).toBeTruthy();
-  expect(validateFIN('M1234567K')).toBeTruthy();
+  expect(validateFIN('M4627182X')).toBe('VALID');
+  expect(validateFIN('M1108730W')).toBe('VALID');
+  expect(validateFIN('M4503401U')).toBe('VALID');
+  expect(validateFIN('M4460557T')).toBe('VALID');
+  expect(validateFIN('M7986532R')).toBe('VALID');
+  expect(validateFIN('M1782041Q')).toBe('VALID');
+  expect(validateFIN('M2682514P')).toBe('VALID');
+  expect(validateFIN('M2966069N')).toBe('VALID');
+  expect(validateFIN('M2966078J')).toBe('VALID');
+  expect(validateFIN('M2083705L')).toBe('VALID');
+  expect(validateFIN('M1234567K')).toBe('VALID');
 
-  expect(validateFIN('M1234567X')).toBeFalsy();
-  expect(validateFIN('M4627182K')).toBeFalsy();
-  expect(validateFIN('M8967779T')).toBeFalsy();
-  expect(validateFIN('M4460557X')).toBeFalsy();
-  expect(validateFIN('M2966069P')).toBeFalsy();
-  expect(validateFIN('M2682514N')).toBeFalsy();
-  expect(validateFIN('M6198505L')).toBeFalsy();
-  expect(validateFIN('M2083705T')).toBeFalsy();
+  expect(validateFIN('M1234567X')).toBe('BAD_CHECKSUM');
+  expect(validateFIN('M4627182K')).toBe('BAD_CHECKSUM');
+  expect(validateFIN('M8967779T')).toBe('BAD_CHECKSUM');
+  expect(validateFIN('M4460557X')).toBe('BAD_CHECKSUM');
+  expect(validateFIN('M2966069P')).toBe('BAD_CHECKSUM');
+  expect(validateFIN('M2682514N')).toBe('BAD_CHECKSUM');
+  expect(validateFIN('M6198505L')).toBe('BAD_CHECKSUM');
+  expect(validateFIN('M2083705T')).toBe('BAD_CHECKSUM');
 });

--- a/personal-calls/backend/src/util/VerifyFIN.ts
+++ b/personal-calls/backend/src/util/VerifyFIN.ts
@@ -33,15 +33,17 @@ const seriesConfigs: Record<string, SeriesConfig> = {
   },
 };
 
-function validateFIN(finLower: string): boolean {
+export type FinResult = 'BAD_FORMAT' | 'BAD_SERIES' | 'BAD_CHECKSUM' | 'VALID';
+
+function validateFIN(finLower: string): FinResult {
   const fin = finLower.trim().toUpperCase();
   if (fin.length !== 9) {
-    return false;
+    return 'BAD_FORMAT';
   }
 
   const conf = seriesConfigs[fin[0]];
   if (!conf) {
-    return false;
+    return 'BAD_SERIES';
   }
 
   const numArray = fin.slice(1, 8).split('').map(Number); // FIN String into array of numbers to multiply by weight
@@ -51,7 +53,10 @@ function validateFIN(finLower: string): boolean {
   } // Cross multiply with weightArray to get sum
   sum += conf.offset;
 
-  return conf.checkArr[sum % 11] === fin.slice(-1);
+  if (conf.checkArr[sum % 11] !== fin.slice(-1)) {
+    return 'BAD_CHECKSUM';
+  }
+  return 'VALID';
 }
 
 export default validateFIN;

--- a/personal-calls/frontend/src/scenes/Verify/VerifyFin.tsx
+++ b/personal-calls/frontend/src/scenes/Verify/VerifyFin.tsx
@@ -1,0 +1,156 @@
+import React, { useEffect, useState } from 'react';
+import TextField from '@material-ui/core/TextField';
+import Typography from '@material-ui/core/Typography';
+import { useTheme } from '@material-ui/core/styles';
+import { useUserService } from 'contexts';
+import { PrimaryButton, Container, Footer } from 'components';
+import { validateFin } from 'services/FinValidation';
+import { Locale, SceneProps } from 'scenes/types';
+
+const EN_STRINGS = {
+  VERIFY_FIN_TITLE: 'Enter your FIN',
+  VERIFY_FIN_FIN_PLACEHOLDER: 'e.g. M1234567X',
+  VERIFY_FIN_HELP:
+    'We need this to verify you’re a foreign worker in Singapore.',
+  VERIFY_FIN_CANCEL: 'Cancel',
+  VERIFY_FIN_WP_LIKE_MESSAGE: 'Enter your FIN, not work pass number',
+  VERIFY_FIN_UNKNOWN_SN_MESSAGE: 'An unknown error has occurred',
+  VERIFY_FIN_CONFLICTING_SN_MESSAGE:
+    'This FIN is already being used by somebody',
+  NEXT: 'Next',
+};
+const STRINGS = {
+  en: EN_STRINGS,
+  bn: {
+    ...EN_STRINGS,
+  },
+};
+
+const WP_SERIAL_NUMBER_REGEX = /[A-Za-z][0-9]{,6}/;
+const FIN_REGEX = /[A-Za-z][0-9]+[A-Za-z]/;
+
+interface VerifyFinPresenterProps {
+  locale: Locale;
+  fin: string;
+  onSubmit: (event: React.FormEvent) => void;
+  onFinChanged: (event: React.ChangeEvent<HTMLInputElement>) => void;
+  errorMessage?: string;
+}
+
+function VerifyFinPresenter({
+  locale,
+  fin,
+  onSubmit,
+  onFinChanged,
+  errorMessage,
+}: VerifyFinPresenterProps) {
+  const theme = useTheme();
+
+  return (
+    <Container>
+      <form
+        onSubmit={onSubmit}
+        style={{ height: '100%', display: 'flex', flexDirection: 'column' }}
+      >
+        <Typography
+          variant="h5"
+          component="h1"
+          style={{ marginBottom: '12px' }}
+        >
+          {STRINGS[locale].VERIFY_FIN_TITLE}
+        </Typography>
+        <Typography>{STRINGS[locale].VERIFY_FIN_HELP}</Typography>
+        <TextField
+          fullWidth
+          autoFocus
+          error={Boolean(errorMessage)}
+          placeholder={STRINGS[locale].VERIFY_FIN_FIN_PLACEHOLDER}
+          value={fin}
+          variant="outlined"
+          onChange={onFinChanged}
+          helperText={errorMessage || ' '}
+          style={{
+            marginBottom: '12px',
+          }}
+        />
+        <PrimaryButton
+          disableFocusRipple
+          color="primary"
+          type="submit"
+          value="submit"
+          style={{
+            marginTop: 'auto',
+          }}
+        >
+          {STRINGS[locale].NEXT}
+        </PrimaryButton>
+      </form>
+      <Footer locale={locale} />
+    </Container>
+  );
+}
+
+export default function VerifyFin({ locale }: SceneProps) {
+  const [, userService] = useUserService();
+
+  const [fin, setFin] = useState('');
+  const [apiErrorMessage, setApiErrorMessage] = useState('');
+  const [isTouched, setIsTouched] = useState(false);
+  useEffect(() => {
+    if (userService) {
+      userService.refreshSelf();
+    }
+  }, [userService]);
+
+  const isValidFin = Boolean(fin.match(FIN_REGEX));
+  const isFinWpLike = Boolean(fin.match(WP_SERIAL_NUMBER_REGEX));
+
+  const onSubmit = async (event: React.FormEvent) => {
+    event.preventDefault();
+    setIsTouched(true);
+    if (isValidFin) {
+      try {
+        setApiErrorMessage('');
+        await validateFin(fin);
+        await userService?.refreshSelf();
+      } catch (error) {
+        setApiErrorMessage(
+          // TODO assume the FIN is invalid until the backend learns better
+          // error reporting.
+          STRINGS[locale].VERIFY_FIN_INVALID_SN_MESSAGE
+        );
+      }
+    }
+  };
+
+  const onFinChanged = (event: React.ChangeEvent<HTMLInputElement>) => {
+    setIsTouched(true);
+    setFin(event.target.value);
+  };
+
+  let errorMessage;
+  if (apiErrorMessage) {
+    errorMessage = apiErrorMessage;
+  } else if (!isTouched) {
+    errorMessage = undefined;
+  } else if (isFinWpLike) {
+    errorMessage = STRINGS[locale].VERIFY_FIN_WP_LIKE_MESSAGE;
+  } else if (!isValidFin) {
+    errorMessage = STRINGS[locale].VERIFY_FIN_INVALID_SN_MESSAGE;
+  } else {
+    errorMessage = undefined;
+  }
+
+  return (
+    <VerifyFinPresenter
+      {...{
+        onSubmit,
+        onFinChanged,
+        locale,
+        fin,
+        setFin,
+        errorMessage,
+      }}
+    />
+  );
+}

--- a/personal-calls/frontend/src/scenes/Verify/index.tsx
+++ b/personal-calls/frontend/src/scenes/Verify/index.tsx
@@ -6,6 +6,7 @@ import { useFeatureService } from 'contexts';
 import VerifyPhoneNumber from './VerifyPhoneNumber';
 import VerifyPhoneNumberCode from './VerifyPhoneNumberCode';
 import VerifyDorm from './VerifyDorm';
+import VerifyFin from './VerifyFin';
 import VerifyWorkpass from './VerifyWorkpass';
 
 function Verify({ locale, routePath }: SceneProps) {
@@ -37,7 +38,14 @@ function Verify({ locale, routePath }: SceneProps) {
   if (featureState?.DORM_VALIDATION) {
     return <VerifyDorm locale={locale} routePath={routePath} />;
   }
-  return <VerifyWorkpass locale={locale} routePath={routePath} />;
+  if (!featureState?.DISABLE_WORKPASS) {
+    return <VerifyWorkpass locale={locale} routePath={routePath} />;
+  }
+  if (featureState?.ENABLE_FIN) {
+    return <VerifyFin locale={locale} routePath={routePath} />;
+  }
+  // We've misconfigured something. Give up and show the generic error page..
+  throw Error('Internal error');
 }
 
 export default Verify;

--- a/personal-calls/frontend/src/scenes/paths.tsx
+++ b/personal-calls/frontend/src/scenes/paths.tsx
@@ -21,14 +21,18 @@ function isUserVerified(
   if (user.verificationState.adminGranted) {
     return true;
   }
-  if (featureState.DORM_VALIDATION) {
-    return (
-      user.verificationState.phoneNumber &&
-      user.verificationState.workpass &&
-      user.verificationState.dorm
-    );
+  let isVerified = true;
+  isVerified = isVerified && user.verificationState.phoneNumber;
+  if (!featureState.DISABLE_WORKPASS) {
+    isVerified = isVerified && user.verificationState.workpass;
   }
-  return user.verificationState.phoneNumber && user.verificationState.workpass;
+  if (featureState.ENABLE_FIN) {
+    isVerified = isVerified && user.verificationState.fin;
+  }
+  if (featureState.DORM_VALIDATION) {
+    isVerified = isVerified && user.verificationState.dorm;
+  }
+  return isVerified;
 }
 
 function routeFromState(

--- a/personal-calls/frontend/src/services/Feature.ts
+++ b/personal-calls/frontend/src/services/Feature.ts
@@ -9,6 +9,8 @@ export interface FeatureState {
   EDGE_EXPERIMENT: Edge;
   FEEDBACK_DIALOG: boolean;
   CREDIT_CAP: boolean;
+  DISABLE_WORKPASS: boolean;
+  ENABLE_FIN: boolean;
 }
 
 const featureEndpoint = '/features';
@@ -21,6 +23,8 @@ export default class FeatureService extends ObservableService<FeatureState> {
       EDGE_EXPERIMENT: Edge.DEFAULT,
       FEEDBACK_DIALOG: false,
       CREDIT_CAP: false,
+      DISABLE_WORKPASS: false,
+      ENABLE_FIN: false,
     };
   }
 

--- a/personal-calls/frontend/src/services/FinValidation.tsx
+++ b/personal-calls/frontend/src/services/FinValidation.tsx
@@ -1,0 +1,9 @@
+import apiClient from './apiClient';
+
+const finEndpoint = '/fin-validation';
+
+export async function validateFin(fin: string) {
+  return apiClient.post(`${finEndpoint}/`, {
+    fin,
+  });
+}

--- a/personal-calls/shared/types/User.ts
+++ b/personal-calls/shared/types/User.ts
@@ -15,6 +15,7 @@ export interface UserWalletResponse {
     workpass: boolean;
     adminGranted: boolean;
     dorm: boolean;
+    fin: boolean;
   };
 
   phoneNumber: string | null;


### PR DESCRIPTION
Fixes https://github.com/bettersg/call-home/issues/140

This will be our replacement for verifying work pass numbers, at least in the interim.

This PR does the following:
* Add FIN verification, largely by copying the existing logic for verifying work pass numbers on the frontend and backend
* Lightly refactor the checks for whether a user is verified so that it's easier to add and remove verification conditions.
* Add feature flags to disable workpass verification and to enable fin verification
