### PR TITLE
personal-calls: add M series to FIN validation

### DIFF
--- a/personal-calls/backend/src/util/VerifyFIN.test.ts
+++ b/personal-calls/backend/src/util/VerifyFIN.test.ts
@@ -27,3 +27,27 @@ test('More than 9 characters', () => {
 test('Numbers only without alphabet', () => {
   expect(validateFIN('123456789')).toBeFalsy();
 });
+
+test('M series', () => {
+  // One of each checksum letter
+  expect(validateFIN('M4627182X')).toBeTruthy();
+  expect(validateFIN('M1108730W')).toBeTruthy();
+  expect(validateFIN('M4503401U')).toBeTruthy();
+  expect(validateFIN('M4460557T')).toBeTruthy();
+  expect(validateFIN('M7986532R')).toBeTruthy();
+  expect(validateFIN('M1782041Q')).toBeTruthy();
+  expect(validateFIN('M2682514P')).toBeTruthy();
+  expect(validateFIN('M2966069N')).toBeTruthy();
+  expect(validateFIN('M2966078J')).toBeTruthy();
+  expect(validateFIN('M2083705L')).toBeTruthy();
+  expect(validateFIN('M1234567K')).toBeTruthy();
+
+  expect(validateFIN('M1234567X')).toBeFalsy();
+  expect(validateFIN('M4627182K')).toBeFalsy();
+  expect(validateFIN('M8967779T')).toBeFalsy();
+  expect(validateFIN('M4460557X')).toBeFalsy();
+  expect(validateFIN('M2966069P')).toBeFalsy();
+  expect(validateFIN('M2682514N')).toBeFalsy();
+  expect(validateFIN('M6198505L')).toBeFalsy();
+  expect(validateFIN('M2083705T')).toBeFalsy();
+});

--- a/personal-calls/backend/src/util/VerifyFIN.ts
+++ b/personal-calls/backend/src/util/VerifyFIN.ts
@@ -1,18 +1,46 @@
 /* Sources:
-References supporting the algorithm
+References supporting the FG algorithm
 http://www.ngiam.net/NRIC/ppframe.htm
 
-To generate and validate FINs
-https://nric.biz
+M algorithm scraped from
 https://samliew.com/nric-generator
+
+See also:
+https://nric.biz (generate and validate FIN)
 */
 
-const checkAlpha = ['X', 'W', 'U', 'T', 'R', 'Q', 'P', 'N', 'M', 'L', 'K'];
+const fgCheck = ['X', 'W', 'U', 'T', 'R', 'Q', 'P', 'N', 'M', 'L', 'K'];
+const mCheck = ['X', 'W', 'U', 'T', 'R', 'Q', 'P', 'N', 'J', 'L', 'K'];
 const weightArray = [2, 7, 6, 5, 4, 3, 2];
+
+interface SeriesConfig {
+  offset: number;
+  checkArr: string[];
+}
+
+const seriesConfigs: Record<string, SeriesConfig> = {
+  F: {
+    offset: 0,
+    checkArr: fgCheck,
+  },
+  G: {
+    offset: 4,
+    checkArr: fgCheck,
+  },
+  M: {
+    offset: 3,
+    checkArr: mCheck,
+  },
+};
 
 function validateFIN(finLower: string): boolean {
   const fin = finLower.trim().toUpperCase();
   if (fin.length !== 9) {
+    return false;
+  }
+
+  const conf = seriesConfigs[fin[0]];
+  if (!conf) {
     return false;
   }
 
@@ -21,12 +49,9 @@ function validateFIN(finLower: string): boolean {
   for (let i = 0; i < numArray.length; i += 1) {
     sum += numArray[i] * weightArray[i];
   } // Cross multiply with weightArray to get sum
+  sum += conf.offset;
 
-  if (fin[0] === 'G') {
-    sum += 4;
-  } // FIN that starts with G has their checkAlpha shifted by 4
-
-  return checkAlpha[sum % 11] === fin.slice(-1);
+  return conf.checkArr[sum % 11] === fin.slice(-1);
 }
 
 export default validateFIN;

--- a/personal-calls/backend/src/util/VerifyFIN.ts
+++ b/personal-calls/backend/src/util/VerifyFIN.ts
@@ -10,9 +10,9 @@ https://samliew.com/nric-generator
 const checkAlpha = ['X', 'W', 'U', 'T', 'R', 'Q', 'P', 'N', 'M', 'L', 'K'];
 const weightArray = [2, 7, 6, 5, 4, 3, 2];
 
-function validateFIN(fin: string): boolean {
-  const finUpper = fin.trim().toUpperCase();
-  if (finUpper.length !== 9) {
+function validateFIN(finLower: string): boolean {
+  const fin = finLower.trim().toUpperCase();
+  if (fin.length !== 9) {
     return false;
   }
 
@@ -22,11 +22,11 @@ function validateFIN(fin: string): boolean {
     sum += numArray[i] * weightArray[i];
   } // Cross multiply with weightArray to get sum
 
-  if (finUpper[0] === 'G') {
+  if (fin[0] === 'G') {
     sum += 4;
   } // FIN that starts with G has their checkAlpha shifted by 4
 
-  return checkAlpha[sum % 11] === finUpper.slice(-1);
+  return checkAlpha[sum % 11] === fin.slice(-1);
 }
 
 export default validateFIN;


### PR DESCRIPTION
Fixes https://github.com/bettersg/call-home/issues/140

This brings ours FIN validation up to date with ICA's new M series of FIN. See the commit messages for detailed descriptions.

It would be helpful if reviewers could verify the test cases with the posted links (just in case).