### PR TITLE
Add HTTP(S) load balancer for GCS bucket

### DIFF
--- a/infra/staging/main.tf
+++ b/infra/staging/main.tf
@@ -39,6 +39,11 @@ variable "frontend_bucket_name" {
   default = "call-home-frontend"
 }
 
+variable "website_domain_name" {
+  type = string
+  default = "app2-staging.callhome.sg"
+}
+
 ######################
 ## Project Settings ##
 ######################
@@ -201,7 +206,7 @@ resource "google_compute_managed_ssl_certificate" "call_home_frontend_lb_ssl" {
   project = data.google_project.project.project_id
 
   managed {
-    domains = ["app2-staging.callhome.sg"]
+    domains = [var.website_domain_name]
   }
 }
 

--- a/infra/staging/main.tf
+++ b/infra/staging/main.tf
@@ -189,8 +189,8 @@ resource "google_compute_backend_bucket" "call_home_frontend_lb" {
 }
 
 // URL map for the backend bucket
-resource "google_compute_url_map" "call_home_frontend_lb_url_map" {
-  name = "call-home-frontend-lb-url-map"
+resource "google_compute_url_map" "call_home_lb" {
+  name = "call-home-lb"
   project = data.google_project.project.project_id
   default_service = google_compute_backend_bucket.call_home_frontend_lb.id
 }
@@ -213,7 +213,7 @@ resource "google_compute_managed_ssl_certificate" "call_home_frontend_lb_ssl" {
 resource "google_compute_target_https_proxy" "call_home_frontend_lb_proxy" {
   name = "call-home-frontend-lb-proxy"
   project = data.google_project.project.project_id
-  url_map = google_compute_url_map.call_home_frontend_lb_url_map.id
+  url_map = google_compute_url_map.call_home_lb.id
 
   ssl_certificates = [
     google_compute_managed_ssl_certificate.call_home_frontend_lb_ssl.name

--- a/infra/staging/main.tf
+++ b/infra/staging/main.tf
@@ -193,6 +193,10 @@ resource "google_compute_url_map" "call_home_lb" {
   name = "call-home-lb"
   project = data.google_project.project.project_id
   default_service = google_compute_backend_bucket.call_home_frontend_lb.id
+
+  depends_on = [
+    google_compute_backend_bucket.call_home_frontend_lb
+  ]
 }
 
 // Setup SSL certificate to enable HTTPS for load balancer
@@ -220,7 +224,8 @@ resource "google_compute_target_https_proxy" "call_home_frontend_lb_proxy" {
   ]
 
   depends_on = [
-    google_compute_managed_ssl_certificate.call_home_frontend_lb_ssl
+    google_compute_managed_ssl_certificate.call_home_frontend_lb_ssl,
+    google_compute_url_map.call_home_lb
   ]
 }
 
@@ -233,6 +238,11 @@ resource "google_compute_global_forwarding_rule" "call_home_frontend_lb_forwardi
   port_range = "443"
   target = google_compute_target_https_proxy.call_home_frontend_lb_proxy.id
   ip_address = google_compute_global_address.call_home_frontend_ip.id
+
+  depends_on = [
+    google_compute_target_https_proxy.call_home_frontend_lb_proxy,
+    google_compute_global_address.call_home_frontend_ip
+  ]
 }
 
 #############

--- a/infra/staging/main.tf
+++ b/infra/staging/main.tf
@@ -155,8 +155,13 @@ resource "google_storage_bucket_iam_member" "frontend_bucket_viewer" {
 ## Load balancer for frontend bucket ##
 #######################################
 
-// NOTE: Had to enable Compute Engine API on the project for this to work
 // Following the guide here: https://cloud.google.com/cdn/docs/setting-up-cdn-with-bucket
+
+// Enable Compute Engine API to setup an IP address
+resource "google_project_service" "compute_engine_api" {
+  project = data.google_project.project.project_id
+  service = "compute.googleapis.com"
+}
 
 // Setup IP address for load balancer
 resource "google_compute_global_address" "call_home_frontend_ip" {

--- a/infra/staging/main.tf
+++ b/infra/staging/main.tf
@@ -210,7 +210,7 @@ resource "google_compute_managed_ssl_certificate" "call_home_frontend_lb_ssl" {
   }
 }
 
-// HTTP proxy
+// HTTPS proxy
 resource "google_compute_target_https_proxy" "call_home_frontend_lb_proxy" {
   name = "call-home-frontend-lb-proxy"
   project = data.google_project.project.project_id
@@ -230,6 +230,32 @@ resource "google_compute_global_forwarding_rule" "call_home_frontend_lb_forwardi
   port_range = "443"
   target = google_compute_target_https_proxy.call_home_frontend_lb_proxy.id
   ip_address = google_compute_global_address.call_home_frontend_ip.id
+}
+
+// The following resources create a partial load balancer
+// for redirecting HTTP to HTTPS
+resource "google_compute_url_map" "call_home_lb_http_redirect" {
+  name = "call-home-lb-http-redirect"
+  project = data.google_project.project.project_id
+
+  default_url_redirect {
+    strip_query            = false
+    https_redirect         = true
+  }
+}
+
+resource "google_compute_target_http_proxy" "call_home_lb_http_redirect" {
+  name    = "call-home-lb-http-redirect-proxy"
+  project = data.google_project.project.project_id
+  url_map = google_compute_url_map.call_home_lb_http_redirect.self_link
+}
+
+resource "google_compute_global_forwarding_rule" "call_home_lb_http_redirect" {
+  name       = "call-home-lb-http-redirect-forwarding-rule"
+  project = data.google_project.project.project_id
+  target     = google_compute_target_http_proxy.call_home_lb_http_redirect.self_link
+  ip_address = google_compute_global_address.call_home_frontend_ip.id
+  port_range = "80"
 }
 
 #############

--- a/infra/staging/main.tf
+++ b/infra/staging/main.tf
@@ -193,10 +193,6 @@ resource "google_compute_url_map" "call_home_lb" {
   name = "call-home-lb"
   project = data.google_project.project.project_id
   default_service = google_compute_backend_bucket.call_home_frontend_lb.id
-
-  depends_on = [
-    google_compute_backend_bucket.call_home_frontend_lb
-  ]
 }
 
 // Setup SSL certificate to enable HTTPS for load balancer
@@ -206,10 +202,6 @@ resource "google_compute_managed_ssl_certificate" "call_home_frontend_lb_ssl" {
 
   managed {
     domains = ["app2-staging.callhome.sg"]
-  }
-
-  lifecycle {
-    create_before_destroy = true
   }
 }
 
@@ -222,11 +214,6 @@ resource "google_compute_target_https_proxy" "call_home_frontend_lb_proxy" {
   ssl_certificates = [
     google_compute_managed_ssl_certificate.call_home_frontend_lb_ssl.name
   ]
-
-  depends_on = [
-    google_compute_managed_ssl_certificate.call_home_frontend_lb_ssl,
-    google_compute_url_map.call_home_lb
-  ]
 }
 
 // Forwarding rule
@@ -238,11 +225,6 @@ resource "google_compute_global_forwarding_rule" "call_home_frontend_lb_forwardi
   port_range = "443"
   target = google_compute_target_https_proxy.call_home_frontend_lb_proxy.id
   ip_address = google_compute_global_address.call_home_frontend_ip.id
-
-  depends_on = [
-    google_compute_target_https_proxy.call_home_frontend_lb_proxy,
-    google_compute_global_address.call_home_frontend_ip
-  ]
 }
 
 #############

--- a/infra/staging/main.tf
+++ b/infra/staging/main.tf
@@ -151,6 +151,7 @@ resource "google_storage_bucket_iam_member" "frontend_bucket_viewer" {
   role   = "roles/storage.objectViewer"
   member = "allUsers"
 }
+
 #######################################
 ## Load balancer for frontend bucket ##
 #######################################
@@ -192,6 +193,16 @@ resource "google_compute_url_map" "call_home_frontend_lb_url_map" {
   name = "call-home-frontend-lb-url-map"
   project = data.google_project.project.project_id
   default_service = google_compute_backend_bucket.call_home_frontend_lb.id
+}
+
+// Setup SSL certificate to enable HTTPS for load balancer
+resource "google_compute_managed_ssl_certificate" "call_home_frontend_lb_ssl" {
+  name = "call-home-frontend-lb-ssl"
+  project = data.google_project.project.project_id
+
+  managed {
+    domains = ["app2-staging.callhome.sg"]
+  }
 }
 
 // HTTP proxy


### PR DESCRIPTION
Fixes https://github.com/bettersg/call-home/issues/150

This PR adds additional resources to the staging Terraform script, with the main goal of enabling serving the frontend (from a GCS bucket) over a static IP address. I used the following guide: https://cloud.google.com/cdn/docs/setting-up-cdn-with-bucket. 

Details on the resources added:
* Compute Engine API service (needed for creating IP address)
* Static IP address for load balancer
* Backend bucket to run the load balancer in
* URL map for the load balancer
* SSL certificate creation for HTTPS capabilities
* HTTPS proxy for the load balancer
* Forwarding rule for the load balancer