### PR TITLE
super-app: create language switching interfaces

### DIFF
--- a/apps/super-app/src/routes/LandingPage.tsx
+++ b/apps/super-app/src/routes/LandingPage.tsx
@@ -4,6 +4,7 @@ import { Box, Typography } from '@mui/material';
 import { Container } from '../common/components';
 import { ServiceCard } from '../common/components/ServiceCard';
 import {
+  useLanguage,
   getServiceCardAbouts,
   getSupportDetailStrings,
   ServiceCardAbout,
@@ -16,8 +17,9 @@ export function LandingPage() {
   const [fixedStrings, setFixedStrings] = useState<SupportDetailStrings | null>(
     null
   );
+  const [lang] = useLanguage();
   useEffect(() => {
-    setFixedStrings(getSupportDetailStrings());
+    setFixedStrings(getSupportDetailStrings(lang));
   }, []);
   if (!fixedStrings) {
     // TODO return something (hint or loading spinner) since this is landing page, we can't return null

--- a/apps/super-app/src/routes/LandingPage.tsx
+++ b/apps/super-app/src/routes/LandingPage.tsx
@@ -8,10 +8,8 @@ import {
   getSupportDetailStrings,
   ServiceCardAbout,
   SupportDetailStrings,
-} from '../services/DetailServices';
+} from '../services';
 import { NavBar } from '../components';
-// TODO export this elegantly so that importers don't have to peek into
-//   components/
 import '../components/navbar/NavBarAbove.css';
 
 export function LandingPage() {

--- a/apps/super-app/src/routes/SupportDetailWip.tsx
+++ b/apps/super-app/src/routes/SupportDetailWip.tsx
@@ -10,6 +10,7 @@ import {
   SupportDetailStrings,
   getSupportDetailStrings,
   getTwc2Detail,
+  useLanguage,
 } from '../services';
 import { Container } from '../common/components';
 import { PrimaryButton } from '../common/components/RoundedButton';
@@ -143,12 +144,13 @@ export function SupportDetailWip() {
   const [fixedStrings, setFixedStrings] = useState<SupportDetailStrings | null>(
     null
   );
+  const [lang] = useLanguage();
   const [content, setContent] = useState<Twc2SupportDetail | null>(null);
   useEffect(() => {
-    setContent(getTwc2Detail());
+    setContent(getTwc2Detail(lang));
   }, []);
   useEffect(() => {
-    setFixedStrings(getSupportDetailStrings());
+    setFixedStrings(getSupportDetailStrings(lang));
   }, []);
   if (!content || !fixedStrings) {
     return null;

--- a/apps/super-app/src/services/CmsSmokeTest.ts
+++ b/apps/super-app/src/services/CmsSmokeTest.ts
@@ -1,6 +1,7 @@
 // TODO This smoke test probably won't be useful in production. Reevaluate when
 // we start testing with real content types.
 const smokeTestEndpoint = '/api/smoke-test';
+const i18nSmokeTestEndpoint = '/api/smoke-test?locale=bn-BD';
 
 // TODO move this into a better module
 // Strapi wraps each model in a "data". Inside which, the things we care about
@@ -22,11 +23,27 @@ async function isUp(): Promise<boolean> {
   return !!json.data.attributes.test;
 }
 
+async function isI18nUp(): Promise<boolean> {
+  const response = await fetch(i18nSmokeTestEndpoint);
+  const json: StrapiModelResponse<SmokeTestView> = await response.json();
+  // Expect that the value we got is actually `true`.
+  return !!json.data.attributes.test;
+}
+
 export async function consoleSmokeTest() {
-  const up = await isUp();
+  // This unnecessarily waits for the slower promise to finish, but at least
+  // it's parallel, looks clean and the speed won't matter anyway.
+  const [up, i18nUp] = await Promise.all([isUp(), isI18nUp()]);
   if (up) {
     console.log('Connected to Strapi backend!!');
-    return;
+  } else {
+    console.error(
+      'Failed to connect to Strapi backend. Bad things might ensue.'
+    );
   }
-  console.error('Failed to connect to Strapi backend. Bad things might ensue.');
+  if (i18nUp) {
+    console.log('i18n enabled on Strapi!');
+  } else {
+    console.error('Failed to detect i18n on Strapi!');
+  }
 }

--- a/apps/super-app/src/services/DetailServices.ts
+++ b/apps/super-app/src/services/DetailServices.ts
@@ -3,6 +3,7 @@
 // TODO remove routes from this page, https://github.com/bettersg/call-home/pull/121#discussion_r1110573633
 import { Path } from '../routes/paths';
 import { Support } from './SupportServices';
+import type { LanguageOption } from './Language';
 
 // Data shared by every Support detail page.
 
@@ -18,10 +19,16 @@ export interface SupportDetailStrings {
   headerTitle: string;
 }
 
-export function getSupportDetailStrings(): SupportDetailStrings {
-  return {
+const SUPPORT_DETAIL_STRINGS: Record<LanguageOption, SupportDetailStrings> = {
+  en: {
     headerTitle: 'Free Support Services',
-  };
+  },
+};
+
+export function getSupportDetailStrings(
+  language: LanguageOption
+): SupportDetailStrings {
+  return SUPPORT_DETAIL_STRINGS[language];
 }
 
 // Data used by every Support detail page that changes per page.
@@ -75,8 +82,8 @@ export function getServiceCardAbouts(): ServiceCardAbout[] {
   ];
 }
 
-export function getTwc2Detail(): Twc2SupportDetail {
-  return {
+const TWC2_DETAIL: Record<LanguageOption, Twc2SupportDetail> = {
+  en: {
     logo: '/images/twc2-logo.png',
     name: 'Transient Workers Count Too (TWC2)',
     website: 'https://twc2.org.sg/language-menu-for-qr-code/',
@@ -99,5 +106,9 @@ export function getTwc2Detail(): Twc2SupportDetail {
     ctaButtonText: '+65 6297 7564',
     ctaLink: 'https://wa.me/6562977564',
     whatsappLogoSrc: '/images/whatsapp-icon.svg',
-  };
+  },
+};
+
+export function getTwc2Detail(language: LanguageOption): Twc2SupportDetail {
+  return TWC2_DETAIL[language];
 }

--- a/apps/super-app/src/services/Language.ts
+++ b/apps/super-app/src/services/Language.ts
@@ -1,0 +1,29 @@
+import { useCallback, useEffect, useState } from 'react';
+
+const LOCAL_STORAGE_KEY = 'lang';
+
+export type LanguageOption = 'en';
+
+export function useLanguage(): [
+  LanguageOption,
+  (lang: LanguageOption) => void
+] {
+  const [lang, setLangInternal] = useState<LanguageOption>('en');
+
+  useEffect(() => {
+    const localStorageLang = localStorage.getItem(LOCAL_STORAGE_KEY);
+    if (localStorageLang) {
+      setLangInternal(localStorageLang as LanguageOption);
+    }
+  }, []);
+
+  const setLang = useCallback(
+    (newLang: LanguageOption) => {
+      setLangInternal(newLang);
+      localStorage.setItem(LOCAL_STORAGE_KEY, newLang);
+    },
+    [setLangInternal]
+  );
+
+  return [lang, setLang];
+}

--- a/apps/super-app/src/services/index.ts
+++ b/apps/super-app/src/services/index.ts
@@ -1,5 +1,9 @@
 export { consoleSmokeTest } from './CmsSmokeTest';
-export { getSupportDetailStrings, getTwc2Detail } from './DetailServices';
+export {
+  getSupportDetailStrings,
+  getTwc2Detail,
+  getServiceCardAbouts,
+} from './DetailServices';
 export type {
   ServiceCardAbout,
   SupportDetailStrings,

--- a/apps/super-app/src/services/index.ts
+++ b/apps/super-app/src/services/index.ts
@@ -11,3 +11,5 @@ export type {
   FacebookLinksSection,
   FacebookLink,
 } from './DetailServices';
+export type { LanguageOption } from './Language';
+export { useLanguage } from './Language';

--- a/services/super-app-cms/README.md
+++ b/services/super-app-cms/README.md
@@ -10,6 +10,15 @@
 - Navigate to roles > Public and grant unauthenticated users `find` permissions
   on Smoke-test.
   
+### Internationalization (i18n)
+
+- Navigate to Settings > Internationalization and add the Bengali (Bangladesh)
+  (bn-BD) locale.
+- Navigate to Content-Type Builder > Smoke-test. Edit the content type and in
+  the modal menu, click 'Enable localization for this Content-Type'.
+- Navigate to Content Manager > smoke-test. On the rght hand side, switch
+  Locales to bn-BD and set the value of field "test" to true.
+
 TODO It's likely that we will have to repeat this authentication step for future
 content types. See if there's a way to set this in code so that we don't have to
 do this continuously.

--- a/services/super-app-cms/src/api/smoke-test/content-types/smoke-test/schema.json
+++ b/services/super-app-cms/src/api/smoke-test/content-types/smoke-test/schema.json
@@ -10,10 +10,19 @@
   "options": {
     "draftAndPublish": false
   },
-  "pluginOptions": {},
+  "pluginOptions": {
+    "i18n": {
+      "localized": true
+    }
+  },
   "attributes": {
     "test": {
-      "type": "boolean"
+      "type": "boolean",
+      "pluginOptions": {
+        "i18n": {
+          "localized": true
+        }
+      }
     }
   }
 }


### PR DESCRIPTION
Fixes #156 

Refactor the internal interfaces in `super-app/` to support different language options so that they will make sense when we introduce Strapi and internationalisation.

Also, demonstrate how to set up and call Strapi's i18n features.
