### PR TITLE
Use Twilio Verify for phone number OTPs

### DIFF
--- a/personal-calls/backend/src/index.ts
+++ b/personal-calls/backend/src/index.ts
@@ -47,7 +47,11 @@ type env = 'development' | 'production' | 'staging';
 
 // Env vars
 const { NODE_ENV } = process.env as { NODE_ENV: env };
-const { PORT = 4000, STATIC_DIR = 'static', FRONTEND_HOST = 'localhost' } = process.env;
+const {
+  PORT = 4000,
+  STATIC_DIR = 'static',
+  FRONTEND_HOST = 'localhost',
+} = process.env;
 
 app.use(morgan('dev'));
 app.use(pinoHttp(httpPinoConfig));

--- a/personal-calls/backend/src/routes/FacebookDormCode.ts
+++ b/personal-calls/backend/src/routes/FacebookDormCode.ts
@@ -35,7 +35,8 @@ function FacebookDormCodeRoutes(
     '/facebook-dorm',
     requireAdmin,
     async (req, res: Response<RedeemableCodeEntity[]>) => {
-      const redeemableCodes = await facebookDormCodeRedemptionService.getUnredeemedCodes();
+      const redeemableCodes =
+        await facebookDormCodeRedemptionService.getUnredeemedCodes();
       return res.json(redeemableCodes);
     }
   );

--- a/personal-calls/backend/src/routes/PhoneNumberValidation.ts
+++ b/personal-calls/backend/src/routes/PhoneNumberValidation.ts
@@ -91,12 +91,8 @@ function PhoneNumberValidationRoutes(
         }
         return res.redirect('/');
       } catch (e) {
-        req.log.error(e.data);
-        const { response } = e;
-        if (response && response.data && response.data.error) {
-          if (response.data.error === 'invalid_grant') {
-            res.status(403).json({ message: 'BAD_OTP' });
-          }
+        if (e.message === 'BAD_OTP') {
+          return res.status(403).json({ message: 'BAD_OTP' });
         }
         return res.status(403).send();
       }

--- a/personal-calls/backend/src/routes/PhoneNumberValidation.ts
+++ b/personal-calls/backend/src/routes/PhoneNumberValidation.ts
@@ -80,8 +80,7 @@ function PhoneNumberValidationRoutes(
       }
       try {
         req.log.info('Received login attempt');
-        const token = await auth0Service.signIn(phoneNumber, code);
-        req.log.info('Received a token', token);
+        await auth0Service.signIn(phoneNumber, code);
         await userService.verifyUserPhoneNumber(userId, phoneNumber);
         const phoneNumberValidation =
           await phoneNumberValidationService.getPhoneNumberValidationForUser(

--- a/personal-calls/backend/src/routes/PhoneNumberValidation.ts
+++ b/personal-calls/backend/src/routes/PhoneNumberValidation.ts
@@ -1,6 +1,6 @@
 import express, { Router } from 'express';
 import * as z from 'zod';
-import type { User, Auth0, PhoneNumberValidation } from '../services';
+import type { User, PhoneLogin, PhoneNumberValidation } from '../services';
 import { normalizePhoneNumber } from '../util/country';
 import { validateRequest } from './helpers/validation';
 
@@ -21,7 +21,7 @@ const LOGIN_SCHEMA = z.object({
 
 function PhoneNumberValidationRoutes(
   userService: typeof User,
-  auth0Service: typeof Auth0,
+  phoneLoginService: typeof PhoneLogin,
   phoneNumberValidationService: typeof PhoneNumberValidation
 ): Router {
   const router = express.Router();
@@ -57,7 +57,7 @@ function PhoneNumberValidationRoutes(
           'SG'
         );
         req.log.info('Phone number is: ', formattedPhoneNumber);
-        await auth0Service.sendSms(formattedPhoneNumber);
+        await phoneLoginService.sendSms(formattedPhoneNumber);
         await phoneNumberValidationService.updatePhoneNumberValidationRequestTime(
           id
         );
@@ -80,7 +80,7 @@ function PhoneNumberValidationRoutes(
       }
       try {
         req.log.info('Received login attempt');
-        await auth0Service.signIn(phoneNumber, code);
+        await phoneLoginService.signIn(phoneNumber, code);
         await userService.verifyUserPhoneNumber(userId, phoneNumber);
         const phoneNumberValidation =
           await phoneNumberValidationService.getPhoneNumberValidationForUser(

--- a/personal-calls/backend/src/routes/index.ts
+++ b/personal-calls/backend/src/routes/index.ts
@@ -26,7 +26,7 @@ const twilioRoute = Twilio(services.Call, services.TwilioCall);
 const oAuthRoute = OAuth(services.User);
 const phoneNumberValidationRoute = PhoneNumberValidation(
   services.User,
-  services.Auth0,
+  services.PhoneLogin,
   services.PhoneNumberValidation
 );
 const userRoute = User(

--- a/personal-calls/backend/src/services/Auth0.ts
+++ b/personal-calls/backend/src/services/Auth0.ts
@@ -1,5 +1,4 @@
-const axios = require('axios');
-const logger = require('pino')();
+import axios from 'axios';
 
 const { AUTH0_DOMAIN, AUTH0_CLIENT_ID, AUTH0_CLIENT_SECRET } = process.env;
 
@@ -12,8 +11,7 @@ function Auth0Service() {
     client_secret: AUTH0_CLIENT_SECRET,
   };
 
-  async function sendSms(phoneNumber) {
-    logger.info('Sending passwordless sms', phoneNumber);
+  async function sendSms(phoneNumber: string): Promise<unknown> {
     const response = await axios.post(`${AUTH0_HOST}/passwordless/start`, {
       ...auth0Args,
       phone_number: phoneNumber,
@@ -22,7 +20,7 @@ function Auth0Service() {
     return response.data;
   }
 
-  async function signIn(phoneNumber, code) {
+  async function signIn(phoneNumber: string, code: string): Promise<unknown> {
     const response = await axios.post(`${AUTH0_HOST}/oauth/token`, {
       ...auth0Args,
       connection: 'sms',
@@ -41,4 +39,4 @@ function Auth0Service() {
   };
 }
 
-module.exports = Auth0Service;
+export default Auth0Service;

--- a/personal-calls/backend/src/services/FacebookDormCodeRedemption.ts
+++ b/personal-calls/backend/src/services/FacebookDormCodeRedemption.ts
@@ -37,9 +37,8 @@ function FacebookDormCodeRedemption(
       throw new Error('Validation Error: WRONG_CODE_HANDLER');
     }
 
-    const previousUserRedemptions = await codeRedemptionService.getRedemptionsForUser(
-      userId
-    );
+    const previousUserRedemptions =
+      await codeRedemptionService.getRedemptionsForUser(userId);
     const redeemedCodes = await Promise.all(
       previousUserRedemptions.map((redemption) =>
         redeemableCodeService.getRedeemableCode(redemption.codeId)

--- a/personal-calls/backend/src/services/Feature.ts
+++ b/personal-calls/backend/src/services/Feature.ts
@@ -12,6 +12,7 @@ const {
   ENABLE_FEEDBACK_DIALOG,
   ENABLE_FIN_VALIDATION,
   ENABLE_SUPPORT_SERVICES,
+  ENABLE_TWILIO_VERIFY,
 } = process.env;
 
 function shouldEnableAllowlistSms(): boolean {
@@ -80,6 +81,10 @@ function shouldEnableFinValidation() {
   return Boolean(ENABLE_FIN_VALIDATION);
 }
 
+function shouldEnableTwilioVerify() {
+  return Boolean(ENABLE_TWILIO_VERIFY);
+}
+
 export {
   shouldDisableAllowlist,
   shouldDisablePeriodicJobs,
@@ -90,5 +95,6 @@ export {
   shouldEnableFeedbackDialog,
   shouldEnableFinValidation,
   shouldEnableSupportServices,
+  shouldEnableTwilioVerify,
   getEdgeExperimentFlag,
 };

--- a/personal-calls/backend/src/services/PhoneLogin.ts
+++ b/personal-calls/backend/src/services/PhoneLogin.ts
@@ -4,7 +4,7 @@ const { AUTH0_DOMAIN, AUTH0_CLIENT_ID, AUTH0_CLIENT_SECRET } = process.env;
 
 const AUTH0_HOST = `https://${AUTH0_DOMAIN}`;
 
-function Auth0Service() {
+function PhoneLoginService() {
   const auth0Args = {
     // domain: AUTH0_DOMAIN,
     client_id: AUTH0_CLIENT_ID,
@@ -39,4 +39,4 @@ function Auth0Service() {
   };
 }
 
-export default Auth0Service;
+export default PhoneLoginService;

--- a/personal-calls/backend/src/services/PhoneLogin.ts
+++ b/personal-calls/backend/src/services/PhoneLogin.ts
@@ -21,16 +21,23 @@ function PhoneLoginService() {
   }
 
   async function signIn(phoneNumber: string, code: string): Promise<unknown> {
-    const response = await axios.post(`${AUTH0_HOST}/oauth/token`, {
-      ...auth0Args,
-      connection: 'sms',
-      grant_type: 'http://auth0.com/oauth/grant-type/passwordless/otp',
-      scope: 'openid',
-      realm: 'sms',
-      username: phoneNumber,
-      otp: code,
-    });
-    return response.data;
+    try {
+      const response = await axios.post(`${AUTH0_HOST}/oauth/token`, {
+        ...auth0Args,
+        connection: 'sms',
+        grant_type: 'http://auth0.com/oauth/grant-type/passwordless/otp',
+        scope: 'openid',
+        realm: 'sms',
+        username: phoneNumber,
+        otp: code,
+      });
+      return response.data;
+    } catch (e) {
+      if (e.response?.data?.error === 'invalid_grant') {
+        throw new Error('BAD_OTP');
+      }
+      throw new Error('UNKNOWN_ERROR');
+    }
   }
 
   return {

--- a/personal-calls/backend/src/services/index.ts
+++ b/personal-calls/backend/src/services/index.ts
@@ -26,7 +26,7 @@ import Contact = require('./Contact');
 import PhoneLogin from './PhoneLogin';
 
 // TOPOLOGICAL SORT LOL
-const phoneLoginService = PhoneLogin();
+const phoneLoginService = PhoneLogin(Feature, TwilioClient);
 
 const dormService = Dorm(models.Dorm);
 const walletService = Wallet(models.Wallet, models.WalletTransaction);

--- a/personal-calls/backend/src/services/index.ts
+++ b/personal-calls/backend/src/services/index.ts
@@ -23,7 +23,7 @@ import Dorm from './Dorm';
 import UserExperimentConfig from './UserExperimentConfig';
 import { CredentialSet, CredentialSets } from './TwilioCreds';
 import Contact = require('./Contact');
-import Auth0 = require('./Auth0');
+import Auth0 from './Auth0';
 
 // TOPOLOGICAL SORT LOL
 const auth0Service = Auth0();

--- a/personal-calls/backend/src/services/index.ts
+++ b/personal-calls/backend/src/services/index.ts
@@ -23,10 +23,10 @@ import Dorm from './Dorm';
 import UserExperimentConfig from './UserExperimentConfig';
 import { CredentialSet, CredentialSets } from './TwilioCreds';
 import Contact = require('./Contact');
-import Auth0 from './Auth0';
+import PhoneLogin from './PhoneLogin';
 
 // TOPOLOGICAL SORT LOL
-const auth0Service = Auth0();
+const phoneLoginService = PhoneLogin();
 
 const dormService = Dorm(models.Dorm);
 const walletService = Wallet(models.Wallet, models.WalletTransaction);
@@ -111,7 +111,7 @@ export {
   WorkpassClient,
   adminGrantedValidationService as AdminGrantedValidation,
   allowlistEntryService as AllowlistEntry,
-  auth0Service as Auth0,
+  phoneLoginService as PhoneLogin,
   callService as Call,
   codeRedemptionService as CodeRedemption,
   contactService as Contact,


### PR DESCRIPTION
As of 2023, Singapore requires that all SMS senders used a registered Sender ID ([IMDA]
(https://www.imda.gov.sg/Content-and-News/Press-Releases-and-Speeches/Press-Releases/2022/Full-SMS-Sender-ID-Registration-to-be-required-by-January-2023)). We are currently in the 'soft enforcement' phase, where non-registered SMSes are given the Sender ID LIKELYSCAM. We will eventually reach the 'hard enforcement' phase where our SMSes will be blocked altogether.

Better.sg doesn't have a registered Sender ID and the process for getting one is unnecessarily cumbersome and expensive. Use Twilio Verify instead, which is a verification service from Twilio that can send SMSes using their own TWVerify Sender ID.