### PR TITLE
personal-calls/frontend: upgrade react-router-dom to v6

### DIFF
--- a/personal-calls/frontend/package-lock.json
+++ b/personal-calls/frontend/package-lock.json
@@ -29,7 +29,7 @@
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "react-imask": "^6.0.5",
-        "react-router-dom": "^5.2.0",
+        "react-router-dom": "^6.4.5",
         "util": "^0.12.5"
       },
       "devDependencies": {
@@ -5389,6 +5389,14 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/popperjs"
+      }
+    },
+    "node_modules/@remix-run/router": {
+      "version": "1.6.3",
+      "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.6.3.tgz",
+      "integrity": "sha512-EXJysQ7J3veRECd0kZFQwYYd5sJMcq2O/m60zu1W2l3oVQ9xtub8jTOtYRE0+M2iomyG/W3Ps7+vp2kna0C27Q==",
+      "engines": {
+        "node": ">=14"
       }
     },
     "node_modules/@rollup/plugin-babel": {
@@ -11486,19 +11494,6 @@
         "he": "bin/he"
       }
     },
-    "node_modules/history": {
-      "version": "4.10.1",
-      "resolved": "https://registry.npmjs.org/history/-/history-4.10.1.tgz",
-      "integrity": "sha512-36nwAD620w12kuzPAsyINPWJqlNbij+hpK1k9XRloDtym8mxzGYl2c17LnV6IAGB2Dmg4tEa7G7DlawS0+qjew==",
-      "dependencies": {
-        "@babel/runtime": "^7.1.2",
-        "loose-envify": "^1.2.0",
-        "resolve-pathname": "^3.0.0",
-        "tiny-invariant": "^1.0.2",
-        "tiny-warning": "^1.0.0",
-        "value-equal": "^1.0.1"
-      }
-    },
     "node_modules/hoist-non-react-statics": {
       "version": "3.3.2",
       "license": "BSD-3-Clause",
@@ -12459,11 +12454,6 @@
       "engines": {
         "node": ">=8"
       }
-    },
-    "node_modules/isarray": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-      "integrity": "sha512-D2S+3GLxWH+uhrNEcoh/fnmYeP8E8/zHl644d/jdA0g2uyXvy3sb0qxotE+ne0LtccHknQzWwZEzhak7oJ0COQ=="
     },
     "node_modules/isexe": {
       "version": "2.0.0",
@@ -14988,14 +14978,6 @@
       "version": "1.0.7",
       "license": "MIT"
     },
-    "node_modules/path-to-regexp": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.8.0.tgz",
-      "integrity": "sha512-n43JRhlUKUAlibEJhPeir1ncUID16QnEjNpwzNdO3Lm4ywrBpBZ5oLD0I6br9evr1Y9JTqwRtAh7JLoOzAQdVA==",
-      "dependencies": {
-        "isarray": "0.0.1"
-      }
-    },
     "node_modules/path-type": {
       "version": "4.0.0",
       "license": "MIT",
@@ -16935,45 +16917,34 @@
       }
     },
     "node_modules/react-router": {
-      "version": "5.3.4",
-      "resolved": "https://registry.npmjs.org/react-router/-/react-router-5.3.4.tgz",
-      "integrity": "sha512-Ys9K+ppnJah3QuaRiLxk+jDWOR1MekYQrlytiXxC1RyfbdsZkS5pvKAzCCr031xHixZwpnsYNT5xysdFHQaYsA==",
+      "version": "6.12.1",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.12.1.tgz",
+      "integrity": "sha512-evd/GrKJOeOypD0JB9e1r7pQh2gWCsTbUfq059Wm1AFT/K2MNZuDo19lFtAgIhlBrp0MmpgpqtvZC7LPAs7vSw==",
       "dependencies": {
-        "@babel/runtime": "^7.12.13",
-        "history": "^4.9.0",
-        "hoist-non-react-statics": "^3.1.0",
-        "loose-envify": "^1.3.1",
-        "path-to-regexp": "^1.7.0",
-        "prop-types": "^15.6.2",
-        "react-is": "^16.6.0",
-        "tiny-invariant": "^1.0.2",
-        "tiny-warning": "^1.0.0"
+        "@remix-run/router": "1.6.3"
+      },
+      "engines": {
+        "node": ">=14"
       },
       "peerDependencies": {
-        "react": ">=15"
+        "react": ">=16.8"
       }
     },
     "node_modules/react-router-dom": {
-      "version": "5.3.4",
-      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-5.3.4.tgz",
-      "integrity": "sha512-m4EqFMHv/Ih4kpcBCONHbkT68KoAeHN4p3lAGoNryfHi0dMy0kCzEZakiKRsvg5wHZ/JLrLW8o8KomWiz/qbYQ==",
+      "version": "6.12.1",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.12.1.tgz",
+      "integrity": "sha512-POIZN9UDKWwEDga054LvYr2KnK8V+0HR4Ny4Bwv8V7/FZCPxJgsCjYxXGxqxzHs7VBxMKZfgvtKhafuJkJSPGA==",
       "dependencies": {
-        "@babel/runtime": "^7.12.13",
-        "history": "^4.9.0",
-        "loose-envify": "^1.3.1",
-        "prop-types": "^15.6.2",
-        "react-router": "5.3.4",
-        "tiny-invariant": "^1.0.2",
-        "tiny-warning": "^1.0.0"
+        "@remix-run/router": "1.6.3",
+        "react-router": "6.12.1"
+      },
+      "engines": {
+        "node": ">=14"
       },
       "peerDependencies": {
-        "react": ">=15"
+        "react": ">=16.8",
+        "react-dom": ">=16.8"
       }
-    },
-    "node_modules/react-router/node_modules/react-is": {
-      "version": "16.13.1",
-      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
-      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
     },
     "node_modules/react-scripts": {
       "version": "5.0.1",
@@ -17484,11 +17455,6 @@
       "engines": {
         "node": ">=4"
       }
-    },
-    "node_modules/resolve-pathname": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/resolve-pathname/-/resolve-pathname-3.0.0.tgz",
-      "integrity": "sha512-C7rARubxI8bXFNB/hqcp/4iUeIXJhJZvFPFPiSPRnhU5UPxzMFIl+2E6yY6c4k9giDJAhtV+enfA+G89N6Csng=="
     },
     "node_modules/resolve-url": {
       "version": "0.2.1",
@@ -19284,16 +19250,6 @@
       "integrity": "sha512-eHY7nBftgThBqOyHGVN+l8gF0BucP09fMo0oO/Lb0w1OF80dJv+lDVpXG60WMQvkcxAkNybKsrEIE3ZtKGmPrA==",
       "dev": true
     },
-    "node_modules/tiny-invariant": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.3.1.tgz",
-      "integrity": "sha512-AD5ih2NlSssTCwsMznbvwMZpJ1cbhkGd2uueNxzv2jDlEeZdU04JQfRnggJQ8DrcVBGjAsCKwFBbDlVNtEMlzw=="
-    },
-    "node_modules/tiny-warning": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/tiny-warning/-/tiny-warning-1.0.3.tgz",
-      "integrity": "sha512-lBN9zLN/oAf68o3zNXYrdCt1kP8WsiGW8Oo2ka41b2IM5JL/S1CTyX1rW0mb/zSuJun0ZUrDxx4sqvYS2FWzPA=="
-    },
     "node_modules/tmpl": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/tmpl/-/tmpl-1.0.5.tgz",
@@ -19828,11 +19784,6 @@
       "engines": {
         "node": ">= 8"
       }
-    },
-    "node_modules/value-equal": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/value-equal/-/value-equal-1.0.1.tgz",
-      "integrity": "sha512-NOJ6JZCAWr0zlxZt+xqCHNTEKOsrks2HQd4MqhP1qy4z1SkbEP467eNx6TgDKXMvUOb+OENfJCZwM+16n7fRfw=="
     },
     "node_modules/vary": {
       "version": "1.1.2",
@@ -24122,6 +24073,11 @@
       "version": "2.11.7",
       "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.11.7.tgz",
       "integrity": "sha512-Cr4OjIkipTtcXKjAsm8agyleBuDHvxzeBoa1v543lbv1YaIwQjESsVcmjiWiPEbC1FIeHOG/Op9kdCmAmiS3Kw=="
+    },
+    "@remix-run/router": {
+      "version": "1.6.3",
+      "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.6.3.tgz",
+      "integrity": "sha512-EXJysQ7J3veRECd0kZFQwYYd5sJMcq2O/m60zu1W2l3oVQ9xtub8jTOtYRE0+M2iomyG/W3Ps7+vp2kna0C27Q=="
     },
     "@rollup/plugin-babel": {
       "version": "5.3.1",
@@ -28445,19 +28401,6 @@
       "integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==",
       "dev": true
     },
-    "history": {
-      "version": "4.10.1",
-      "resolved": "https://registry.npmjs.org/history/-/history-4.10.1.tgz",
-      "integrity": "sha512-36nwAD620w12kuzPAsyINPWJqlNbij+hpK1k9XRloDtym8mxzGYl2c17LnV6IAGB2Dmg4tEa7G7DlawS0+qjew==",
-      "requires": {
-        "@babel/runtime": "^7.1.2",
-        "loose-envify": "^1.2.0",
-        "resolve-pathname": "^3.0.0",
-        "tiny-invariant": "^1.0.2",
-        "tiny-warning": "^1.0.0",
-        "value-equal": "^1.0.1"
-      }
-    },
     "hoist-non-react-statics": {
       "version": "3.3.2",
       "requires": {
@@ -29096,11 +29039,6 @@
       "requires": {
         "is-docker": "^2.0.0"
       }
-    },
-    "isarray": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-      "integrity": "sha512-D2S+3GLxWH+uhrNEcoh/fnmYeP8E8/zHl644d/jdA0g2uyXvy3sb0qxotE+ne0LtccHknQzWwZEzhak7oJ0COQ=="
     },
     "isexe": {
       "version": "2.0.0",
@@ -30939,14 +30877,6 @@
     "path-parse": {
       "version": "1.0.7"
     },
-    "path-to-regexp": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.8.0.tgz",
-      "integrity": "sha512-n43JRhlUKUAlibEJhPeir1ncUID16QnEjNpwzNdO3Lm4ywrBpBZ5oLD0I6br9evr1Y9JTqwRtAh7JLoOzAQdVA==",
-      "requires": {
-        "isarray": "0.0.1"
-      }
-    },
     "path-type": {
       "version": "4.0.0"
     },
@@ -32174,40 +32104,20 @@
       "dev": true
     },
     "react-router": {
-      "version": "5.3.4",
-      "resolved": "https://registry.npmjs.org/react-router/-/react-router-5.3.4.tgz",
-      "integrity": "sha512-Ys9K+ppnJah3QuaRiLxk+jDWOR1MekYQrlytiXxC1RyfbdsZkS5pvKAzCCr031xHixZwpnsYNT5xysdFHQaYsA==",
+      "version": "6.12.1",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.12.1.tgz",
+      "integrity": "sha512-evd/GrKJOeOypD0JB9e1r7pQh2gWCsTbUfq059Wm1AFT/K2MNZuDo19lFtAgIhlBrp0MmpgpqtvZC7LPAs7vSw==",
       "requires": {
-        "@babel/runtime": "^7.12.13",
-        "history": "^4.9.0",
-        "hoist-non-react-statics": "^3.1.0",
-        "loose-envify": "^1.3.1",
-        "path-to-regexp": "^1.7.0",
-        "prop-types": "^15.6.2",
-        "react-is": "^16.6.0",
-        "tiny-invariant": "^1.0.2",
-        "tiny-warning": "^1.0.0"
-      },
-      "dependencies": {
-        "react-is": {
-          "version": "16.13.1",
-          "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
-          "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
-        }
+        "@remix-run/router": "1.6.3"
       }
     },
     "react-router-dom": {
-      "version": "5.3.4",
-      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-5.3.4.tgz",
-      "integrity": "sha512-m4EqFMHv/Ih4kpcBCONHbkT68KoAeHN4p3lAGoNryfHi0dMy0kCzEZakiKRsvg5wHZ/JLrLW8o8KomWiz/qbYQ==",
+      "version": "6.12.1",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.12.1.tgz",
+      "integrity": "sha512-POIZN9UDKWwEDga054LvYr2KnK8V+0HR4Ny4Bwv8V7/FZCPxJgsCjYxXGxqxzHs7VBxMKZfgvtKhafuJkJSPGA==",
       "requires": {
-        "@babel/runtime": "^7.12.13",
-        "history": "^4.9.0",
-        "loose-envify": "^1.3.1",
-        "prop-types": "^15.6.2",
-        "react-router": "5.3.4",
-        "tiny-invariant": "^1.0.2",
-        "tiny-warning": "^1.0.0"
+        "@remix-run/router": "1.6.3",
+        "react-router": "6.12.1"
       }
     },
     "react-scripts": {
@@ -32551,11 +32461,6 @@
     },
     "resolve-from": {
       "version": "4.0.0"
-    },
-    "resolve-pathname": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/resolve-pathname/-/resolve-pathname-3.0.0.tgz",
-      "integrity": "sha512-C7rARubxI8bXFNB/hqcp/4iUeIXJhJZvFPFPiSPRnhU5UPxzMFIl+2E6yY6c4k9giDJAhtV+enfA+G89N6Csng=="
     },
     "resolve-url": {
       "version": "0.2.1",
@@ -33841,16 +33746,6 @@
       "integrity": "sha512-eHY7nBftgThBqOyHGVN+l8gF0BucP09fMo0oO/Lb0w1OF80dJv+lDVpXG60WMQvkcxAkNybKsrEIE3ZtKGmPrA==",
       "dev": true
     },
-    "tiny-invariant": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.3.1.tgz",
-      "integrity": "sha512-AD5ih2NlSssTCwsMznbvwMZpJ1cbhkGd2uueNxzv2jDlEeZdU04JQfRnggJQ8DrcVBGjAsCKwFBbDlVNtEMlzw=="
-    },
-    "tiny-warning": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/tiny-warning/-/tiny-warning-1.0.3.tgz",
-      "integrity": "sha512-lBN9zLN/oAf68o3zNXYrdCt1kP8WsiGW8Oo2ka41b2IM5JL/S1CTyX1rW0mb/zSuJun0ZUrDxx4sqvYS2FWzPA=="
-    },
     "tmpl": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/tmpl/-/tmpl-1.0.5.tgz",
@@ -34226,11 +34121,6 @@
           "dev": true
         }
       }
-    },
-    "value-equal": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/value-equal/-/value-equal-1.0.1.tgz",
-      "integrity": "sha512-NOJ6JZCAWr0zlxZt+xqCHNTEKOsrks2HQd4MqhP1qy4z1SkbEP467eNx6TgDKXMvUOb+OENfJCZwM+16n7fRfw=="
     },
     "vary": {
       "version": "1.1.2",

--- a/personal-calls/frontend/package.json
+++ b/personal-calls/frontend/package.json
@@ -24,7 +24,7 @@
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-imask": "^6.0.5",
-    "react-router-dom": "^5.2.0",
+    "react-router-dom": "^6.4.5",
     "util": "^0.12.5"
   },
   "scripts": {

--- a/personal-calls/frontend/src/scenes/CallingPage.tsx
+++ b/personal-calls/frontend/src/scenes/CallingPage.tsx
@@ -7,7 +7,7 @@ import { withStyles } from 'hack/withStyles';
 import Button from '@mui/material/Button';
 import Typography from '@mui/material/Typography';
 import { DateTime } from 'luxon';
-import { Redirect } from 'react-router-dom';
+import { Navigate } from 'react-router-dom';
 import {
   useUserService,
   useContactService,
@@ -320,7 +320,7 @@ export default function CallingPage({ locale }: SceneProps) {
   }, [contactService, disconnectCall]);
 
   if (!user || !activeContact) {
-    return <Redirect to={PATHS.HOME} />;
+    return <Navigate to={PATHS.HOME} replace />;
   }
 
   const onSubmitFeedback = (feedback: number, qualityIssue?: string) => {

--- a/personal-calls/frontend/src/scenes/Home/ContactsPage.tsx
+++ b/personal-calls/frontend/src/scenes/Home/ContactsPage.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect } from 'react';
-import { Redirect, Link, useLocation, useHistory } from 'react-router-dom';
+import { Navigate, Link, useLocation, useNavigate } from 'react-router-dom';
 import List from '@mui/material/List';
 import ListItem from '@mui/material/ListItem';
 import Typography from '@mui/material/Typography';
@@ -540,7 +540,7 @@ function CallContactButton({
 
 const dialogHashId = '#new-contact';
 export default function ContactsPage({ locale }: SceneProps) {
-  const history = useHistory();
+  const navigate = useNavigate();
   const location = useLocation();
   const [userState, userService] = useUserService();
   const { me: user } = userState || {};
@@ -574,7 +574,7 @@ export default function ContactsPage({ locale }: SceneProps) {
   }, []);
 
   if (activeContact) {
-    return <Redirect to={PATHS.CALLING} />;
+    return <Navigate to={PATHS.CALLING} replace />;
   }
 
   const userCallTimeDuration = Duration.fromObject({
@@ -767,7 +767,7 @@ export default function ContactsPage({ locale }: SceneProps) {
           }}
           variant="outlined"
           onClick={() => {
-            history.push(dialogHashId);
+            navigate(dialogHashId);
           }}
         >
           <AddContactIcon
@@ -790,7 +790,7 @@ export default function ContactsPage({ locale }: SceneProps) {
       >
         <AddContactDialog
           onClose={() => {
-            history.replace('');
+            navigate('');
           }}
           open={isAddDialogOpen}
           locale={locale}

--- a/personal-calls/frontend/src/scenes/Home/index.tsx
+++ b/personal-calls/frontend/src/scenes/Home/index.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Redirect } from 'react-router-dom';
+import { Navigate } from 'react-router-dom';
 import { SceneProps } from 'scenes/types';
 import PATHS, { useReadyUserState, isUserVerified } from 'scenes/paths';
 import { useFeatureService } from 'contexts';
@@ -19,7 +19,7 @@ function Home({ locale, routePath }: SceneProps) {
   }
 
   if (!isUserVerified(user, featureState)) {
-    return <Redirect to={PATHS.VERIFY} />;
+    return <Navigate to={PATHS.VERIFY} replace />;
   }
   return <ContactsPage locale={locale} routePath={routePath} />;
 }

--- a/personal-calls/frontend/src/scenes/PromoCode.tsx
+++ b/personal-calls/frontend/src/scenes/PromoCode.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect, FormEvent } from 'react';
-import { useHistory } from 'react-router-dom';
+import { useNavigate } from 'react-router-dom';
 import TextField from '@mui/material/TextField';
 import Typography from '@mui/material/Typography';
 import { useRedeemableCodeService } from 'contexts';
@@ -32,7 +32,7 @@ const STRINGS: Record<string, typeof EN_STRINGS> = {
 
 export default function PromoCode({ locale, routePath }: SceneProps) {
   const [, redeemableCodeService] = useRedeemableCodeService();
-  const history = useHistory();
+  const navigate = useNavigate();
   const routeResult = useAuthRouting(routePath);
   const [codeClaimed, setCodeClaimed] = useState(false);
   const [errorMessage, setErrorMessage] = useState('');
@@ -127,7 +127,7 @@ export default function PromoCode({ locale, routePath }: SceneProps) {
           style={{
             marginTop: '12px',
           }}
-          onClick={() => history.push(PATHS.HOME)}
+          onClick={() => navigate(PATHS.HOME)}
         >
           {STRINGS[locale].CLOSE}
         </ErrorButton>

--- a/personal-calls/frontend/src/scenes/SceneRouter.tsx
+++ b/personal-calls/frontend/src/scenes/SceneRouter.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Switch, Route } from 'react-router-dom';
+import { Routes, Route } from 'react-router-dom';
 import PATHS from './paths';
 import {
   AdminPage,
@@ -25,28 +25,29 @@ export default function SceneRouter() {
     (queryLang as Locale) || (localStorageLang as Locale) || 'bn';
 
   return (
-    <Switch>
-      <Route path={PATHS.ADMIN}>
-        <AdminPage />
-      </Route>
-      <Route path={PATHS.CALLING}>
-        <CallingPage locale={locale} routePath={PATHS.CALLING} />
-      </Route>
-      <Route path={PATHS.TRANSACTIONS}>
-        <TransactionsPage />
-      </Route>
-      <Route path={PATHS.PROMO_CODE}>
-        <PromoCode locale={locale} routePath={PATHS.PROMO_CODE} />
-      </Route>
-      <Route path={PATHS.RECENT_CALLS}>
-        <RecentCallsPage locale={locale} />
-      </Route>
-      <Route path={PATHS.VERIFY}>
-        <Verify locale={locale} routePath={PATHS.VERIFY} />
-      </Route>
-      <Route path={PATHS.HOME}>
-        <Home locale={locale} routePath={PATHS.HOME} />
-      </Route>
-    </Switch>
+    <Routes>
+      <Route path={PATHS.ADMIN} element={<AdminPage />} />
+      <Route
+        path={PATHS.CALLING}
+        element={<CallingPage locale={locale} routePath={PATHS.CALLING} />}
+      />
+      <Route path={PATHS.TRANSACTIONS} element={<TransactionsPage />} />
+      <Route
+        path={PATHS.PROMO_CODE}
+        element={<PromoCode locale={locale} routePath={PATHS.PROMO_CODE} />}
+      />
+      <Route
+        path={PATHS.RECENT_CALLS}
+        element={<RecentCallsPage locale={locale} />}
+      />
+      <Route
+        path={PATHS.VERIFY}
+        element={<Verify locale={locale} routePath={PATHS.VERIFY} />}
+      />
+      <Route
+        path="/*"
+        element={<Home locale={locale} routePath={PATHS.HOME} />}
+      />
+    </Routes>
   );
 }

--- a/personal-calls/frontend/src/scenes/TransactionsPage.js
+++ b/personal-calls/frontend/src/scenes/TransactionsPage.js
@@ -1,4 +1,4 @@
-import { Link, Redirect } from 'react-router-dom';
+import { Link, Navigate } from 'react-router-dom';
 import Typography from '@mui/material/Typography';
 import Table from '@mui/material/Table';
 import TableContainer from '@mui/material/TableContainer';
@@ -47,7 +47,7 @@ export default function TransactionsPage() {
   };
 
   if (!userId) {
-    return <Redirect to={PATHS.ADMIN} />;
+    return <Navigate to={PATHS.ADMIN} replace />;
   }
 
   return (

--- a/personal-calls/frontend/src/scenes/Verify/index.tsx
+++ b/personal-calls/frontend/src/scenes/Verify/index.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Redirect } from 'react-router-dom';
+import { Navigate } from 'react-router-dom';
 import { SceneProps } from 'scenes/types';
 import PATHS, { useReadyUserState, isUserVerified } from 'scenes/paths';
 import { useFeatureService } from 'contexts';
@@ -18,7 +18,7 @@ function Verify({ locale, routePath }: SceneProps) {
 
   const user = userState.me;
   if (!user || isUserVerified(user, featureState)) {
-    return <Redirect to={PATHS.HOME} />;
+    return <Navigate to={PATHS.HOME} replace />;
   }
 
   // Verify phone number before work pass.

--- a/personal-calls/frontend/src/scenes/paths.tsx
+++ b/personal-calls/frontend/src/scenes/paths.tsx
@@ -1,6 +1,6 @@
 import { UserWalletResponse } from '@call-home/shared/types/User';
 import React, { useState, useEffect } from 'react';
-import { Redirect } from 'react-router-dom';
+import { Navigate } from 'react-router-dom';
 import { useUserService, useFeatureService } from '../contexts';
 import { UserState, FeatureState } from '../services';
 
@@ -105,7 +105,7 @@ function useAuthRouting(ownRoute: string): RoutingResult {
   if (route && route !== ownRoute) {
     return {
       ready: true,
-      renderElement: <Redirect to={route} />,
+      renderElement: <Navigate to={route} replace />,
     };
   }
 

--- a/personal-calls/frontend/src/util/useAdminRoute.tsx
+++ b/personal-calls/frontend/src/util/useAdminRoute.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect } from 'react';
-import { Redirect } from 'react-router-dom';
+import { Navigate } from 'react-router-dom';
 import { useUserService } from '../contexts';
 import PATHS from '../scenes/paths';
 
@@ -15,7 +15,7 @@ export default function useAdminRoute() {
   }, [userService]);
 
   if (!user && !userRequestInFlight) {
-    return <Redirect to={PATHS.HOME} />;
+    return <Navigate to={PATHS.HOME} replace />;
   }
   return null;
 }


### PR DESCRIPTION
We'll need this in order to eventually move the `NavBar` component into the 'shared' module (https://github.com/bettersg/call-home/pull/182), because that uses `react-router` navigation.