### PR TITLE
[personal-calls] Update credit top-up to 40 mins

### DIFF
--- a/personal-calls/backend/src/services/PeriodicCredit.ts
+++ b/personal-calls/backend/src/services/PeriodicCredit.ts
@@ -16,7 +16,7 @@ import { shouldEnableCreditCap } from './Feature';
 
 // Config object for handling multiple credit intervals for users. No longer necessary.
 const cohorts = {
-  month: Duration.fromObject({ minutes: 80 }),
+  month: Duration.fromObject({ minutes: 40 }),
 };
 
 const CREDIT_INTERVAL = 'month';


### PR DESCRIPTION
Updates the top-up credit to 40 mins instead of 80 mins, so that the funds for calls last longer.